### PR TITLE
Use full version for ubuntu repo paths

### DIFF
--- a/tasks/repository.yml
+++ b/tasks/repository.yml
@@ -12,7 +12,7 @@
 
 - name: Add Microsoft apt repository for Defender.
   apt_repository:
-    repo: "deb [arch=arm64,armhf,amd64] https://packages.microsoft.com/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/prod {{ (channel == 'prod') | ternary(ansible_distribution_release, channel) }} main" # noqa 204
+    repo: "deb [arch=arm64,armhf,amd64] https://packages.microsoft.com/{{ ansible_distribution | lower }}/{{ ansible_distribution_version }}/prod {{ (channel == 'prod') | ternary(ansible_distribution_release, channel) }} main" # noqa 204
     filename: "microsoft-{{ channel }}.list"
     update_cache: yes
     state: "{{ uninstall | ternary ('absent', 'present') }}"


### PR DESCRIPTION
Use full version instead of just major for ubuntu repo paths - appears MS have changed the location since this role was written.